### PR TITLE
Add non-generic overload of CreateInstance

### DIFF
--- a/LazyProxy.Tests/LazyProxyBuilderTests.cs
+++ b/LazyProxy.Tests/LazyProxyBuilderTests.cs
@@ -364,6 +364,37 @@ namespace LazyProxy.Tests
         }
 
         [Fact]
+        public void GenericInterfacesMustBeProxiedByNonGenericMethod()
+        {
+            var arg1 = new TestArgument2();
+            var arg2 = new TestArgument();
+            var expectedResult1 = new TestArgument4();
+            var expectedResult2 = new TestArgument2();
+
+            var proxyObject = LazyProxyBuilder.CreateInstance(
+                typeof(IGenericTestService<TestArgument2, TestArgument, TestArgument4>), () =>
+                {
+                    var mock = new Mock<IGenericTestService<TestArgument2, TestArgument, TestArgument4>>(
+                        MockBehavior.Strict);
+
+                    mock.Setup(s => s.Method1(arg1, arg2)).Returns(expectedResult1);
+                    mock.Setup(s => s.Method2(arg1, arg2)).Returns(expectedResult2);
+
+                    return mock.Object;
+                });
+
+            var proxy = proxyObject as IGenericTestService<TestArgument2, TestArgument, TestArgument4>;
+
+            Assert.NotNull(proxy);
+
+            var actualResult1 = proxy.Method1(arg1, arg2);
+            var actualResult2 = proxy.Method2(arg1, arg2);
+
+            Assert.Equal(expectedResult1, actualResult1);
+            Assert.Equal(expectedResult2, actualResult2);
+        }
+
+        [Fact]
         public void GenericInterfaceWithDifferentTypeParametersMustBeCreatedWithoutExceptions()
         {
             var exception = Record.Exception(() =>

--- a/LazyProxy/LazyBuilder.cs
+++ b/LazyProxy/LazyBuilder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace LazyProxy
+{
+    /// <summary>
+    /// Is used to create at runtime instances of <see cref="Lazy{T}"/>.
+    /// </summary>
+    public static class LazyBuilder
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="Lazy{T}"/>.
+        /// </summary>
+        /// <param name="valueFactory">Function that returns a value.</param>
+        /// <typeparam name="T">Type of lazy value.</typeparam>
+        /// <returns>Instance of <see cref="Lazy{T}"/></returns>
+        public static Lazy<T> CreateInstance<T>(Func<object> valueFactory)
+        {
+            return new Lazy<T>(() => (T) valueFactory());
+        }
+    }
+}

--- a/LazyProxy/LazyBuilder.cs
+++ b/LazyProxy/LazyBuilder.cs
@@ -3,7 +3,7 @@
 namespace LazyProxy
 {
     /// <summary>
-    /// Is used to create at runtime instances of <see cref="Lazy{T}"/>.
+    /// This type hosts factory method that creates <see cref="Lazy{T}"/> instances.
     /// </summary>
     public static class LazyBuilder
     {

--- a/LazyProxy/LazyProxyBase.cs
+++ b/LazyProxy/LazyProxyBase.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace LazyProxy
+{
+    /// <summary>
+    /// Base class for lazy proxies.
+    /// </summary>
+    public abstract class LazyProxyBase
+    {
+        /// <summary>
+        /// Initialize inner service of <see cref="Lazy{T}"/> by value factory.
+        /// </summary>
+        /// <param name="valueFactory">Function that returns a value.</param>
+        public abstract void Initialize(Func<object> valueFactory);
+    }
+}

--- a/LazyProxy/LazyProxyBase.cs
+++ b/LazyProxy/LazyProxyBase.cs
@@ -8,7 +8,7 @@ namespace LazyProxy
     public abstract class LazyProxyBase
     {
         /// <summary>
-        /// Initialize inner service of <see cref="Lazy{T}"/> by value factory.
+        /// Initializes inner <see cref="Lazy{T}"/> instance with the valueFactory provided.
         /// </summary>
         /// <param name="valueFactory">Function that returns a value.</param>
         public abstract void Initialize(Func<object> valueFactory);

--- a/LazyProxy/LazyProxyBuilder.cs
+++ b/LazyProxy/LazyProxyBuilder.cs
@@ -69,7 +69,7 @@ namespace LazyProxy
         /// <returns>The lazy proxy type instance.</returns>
         public static T CreateInstance<T>(Func<T> valueFactory)
         {
-            return (T) CreateInstance(typeof(T), () => valueFactory());
+            return (T) CreateInstance(typeof(T), valueFactory as Func<object>);
         }
 
         /// <summary>

--- a/LazyProxy/LazyProxyBuilder.cs
+++ b/LazyProxy/LazyProxyBuilder.cs
@@ -107,7 +107,7 @@ namespace LazyProxy
         /// {
         ///     private Lazy<IMyService> _service;
         ///
-        ///     public LazyProxyImpl_1eb94ccd79fd48af8adfbc97c76c10ff_IMyService(Func<object> valueFactory)
+        ///     public void Initialize(Func<object> valueFactory)
         ///     {
         ///         _service = LazyBuilder.CreateInstance<IMyService>(valueFactory);
         ///     }

--- a/LazyProxy/LazyProxyBuilder.cs
+++ b/LazyProxy/LazyProxyBuilder.cs
@@ -25,6 +25,9 @@ namespace LazyProxy
         private static readonly ConcurrentDictionary<Type, Lazy<Type>> ProxyTypes =
             new ConcurrentDictionary<Type, Lazy<Type>>();
 
+        private static readonly MethodInfo CreateLazyMethod = typeof(LazyBuilder)
+            .GetMethod("CreateInstance", BindingFlags.Public | BindingFlags.Static);
+
         /// <summary>
         /// Defines at runtime a class that implements interface T
         /// and proxies all invocations to <see cref="Lazy{T}"/> of this interface.
@@ -170,10 +173,7 @@ namespace LazyProxy
                 new [] { typeof(Func<object>) }
             );
 
-            // ReSharper disable once PossibleNullReferenceException
-            var createLazyMethod = typeof(LazyBuilder)
-                .GetMethod("CreateInstance", BindingFlags.Public | BindingFlags.Static)
-                .MakeGenericMethod(type);
+            var createLazyMethod = CreateLazyMethod.MakeGenericMethod(type);
 
             var generator = methodBuilder.GetILGenerator();
 

--- a/LazyProxy/LazyProxyBuilder.cs
+++ b/LazyProxy/LazyProxyBuilder.cs
@@ -50,6 +50,11 @@ namespace LazyProxy
                 throw new NotSupportedException("The lazy proxy is supported only for interfaces.");
             }
 
+            if (type.IsConstructedGenericType)
+            {
+                type = type.GetGenericTypeDefinition();
+            }
+
             // Lazy is used to guarantee the valueFactory is invoked only once.
             // More info: http://reedcopsey.com/2011/01/16/concurrentdictionarytkeytvalue-used-with-lazyt/
             var lazy = ProxyTypes.GetOrAdd(type, t => new Lazy<Type>(() => DefineProxyType(t)));
@@ -64,8 +69,15 @@ namespace LazyProxy
         /// <returns>The lazy proxy type instance.</returns>
         public static T CreateInstance<T>(Func<T> valueFactory)
         {
+            var type = typeof(T);
             var lazy = new Lazy<T>(valueFactory);
             var proxyType = GetType<T>();
+
+            if (type.IsConstructedGenericType)
+            {
+                proxyType = proxyType.MakeGenericType(type.GetGenericArguments());
+            }
+
             return (T) Activator.CreateInstance(proxyType, lazy);
         }
 

--- a/LazyProxy/LazyProxyBuilder.cs
+++ b/LazyProxy/LazyProxyBuilder.cs
@@ -31,7 +31,7 @@ namespace LazyProxy
         /// </summary>
         /// <typeparam name="T">The interface proxy type implements.</typeparam>
         /// <returns>The lazy proxy type.</returns>
-        public static Type GetType<T>()
+        public static Type GetType<T>() where T : class
         {
             return GetType(typeof(T));
         }
@@ -67,9 +67,9 @@ namespace LazyProxy
         /// <param name="valueFactory">The function real value returns.</param>
         /// <typeparam name="T">The interface proxy type implements.</typeparam>
         /// <returns>The lazy proxy type instance.</returns>
-        public static T CreateInstance<T>(Func<T> valueFactory)
+        public static T CreateInstance<T>(Func<T> valueFactory) where T : class
         {
-            return (T) CreateInstance(typeof(T), valueFactory as Func<object>);
+            return (T) CreateInstance(typeof(T), valueFactory);
         }
 
         /// <summary>


### PR DESCRIPTION
- Generic types will cause generating of open-generic proxies only;
- Non-generic overload of `CreateInstance` is added;
- Method `Initialize` is used instead of `ctor` to improve performance
- Argument of proxy is changed from `Lazy<IService<T>>` to `Func<object>`
- Class constraint for `T` is added.